### PR TITLE
feat: implement W3C WebMCP browser-native search integration

### DIFF
--- a/openspec/changes/archive/2026-03-31-webmcp-search-input/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-31-webmcp-search-input/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/archive/2026-03-31-webmcp-search-input/design.md
+++ b/openspec/changes/archive/2026-03-31-webmcp-search-input/design.md
@@ -1,0 +1,25 @@
+## Context
+AI agents need a standardized way to interact with our search functionality. The official W3C WebMCP standard is a browser-native JavaScript API that allows websites to register tools directly in the frontend context, executed natively by the browser on the agent's behalf.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make site search discoverable and usable by AI agents using the official WebMCP JavaScript API (`navigator.modelContext.registerTool`).
+- Ensure the agent receives structured JSON data back from its search execution.
+- Validate the integration with a proper `@SpringBootTest` that runs in the CI/CD build pipeline.
+
+**Non-Goals:**
+- Using outdated, static JSON payload manifests (`webmcp.json`).
+- Building fragile standalone demo scripts that don't hook into the test suite.
+
+## Decisions
+
+- **Decision: Dynamic Browser-Native Integration via JavaScript**
+  - **Rationale**: The official W3C draft for WebMCP uses an imperative JavaScript API (`navigator.modelContext.registerTool`). This ensures compatibility with upcoming browser features (e.g., Chrome 146+) and eliminates the need for separate manifest files.
+- **Decision: Add JSON Search Endpoint**
+  - **Rationale**: Since the WebMCP JavaScript execution block uses `fetch` and expects a JSON return object, we will extend `NewCatalogController.java` to provide a dedicated `/api/v2/catalog/search` endpoint instead of relying on the legacy HTML-returning `SearchController`.
+
+## Risks / Trade-offs
+
+- **Risk**: The `navigator.modelContext` API is still an early W3C draft and behind browser flags.
+  - **Mitigation**: We wrap the registration in a safety check (`if (window.navigator.modelContext)`) so it does not throw errors on standard browsers lacking the API.

--- a/openspec/changes/archive/2026-03-31-webmcp-search-input/proposal.md
+++ b/openspec/changes/archive/2026-03-31-webmcp-search-input/proposal.md
@@ -1,0 +1,22 @@
+## Why
+AI agents increasingly interact with web applications to perform tasks on behalf of users. Currently, agents often rely on fragile DOM scraping or unstructured guesswork to find and use site features like search. Web Model Context Protocol (WebMCP) offers a standardized way to expose website functionality directly to AI agents. By implementing WebMCP for our search input, we create a robust, reliable "agent-ready" interface and a live showcase demonstrating how WebMCP bridges the gap between human-centric UIs and AI automation.
+
+## What Changes
+- Add WebMCP declarative annotations (e.g., `data-mcp-action`, tool schemas) to the existing site search functionality.
+- Enable AI agents to discover the search tool and its expected input structure programmatically.
+- Provide comprehensive documentation describing how the WebMCP search integration works and how external agents can utilize it.
+- Implement an automated test to reliably verify the WebMCP metadata and ensure the search functionality remains agent-discoverable over time.
+
+## Capabilities
+
+### New Capabilities
+- `webmcp-search-integration`: Defines the standard for exposing the site's search functionality to AI agents via WebMCP, including discoverability, expected inputs, testing, and agent usage instructions.
+
+### Modified Capabilities
+*(None)*
+
+## Impact
+- **UI/HTML Structure**: The primary search form/input will be augmented with WebMCP data attributes or manifest links.
+- **Documentation**: New developer/agent documentation explaining the WebMCP tooling.
+- **Testing**: A new automated test suite will be introduced to validate the presence and correctness of WebMCP integration.
+- **User Experience (Human)**: No visible changes or disruptions for human users; all changes are "under the hood" for agent consumption.

--- a/openspec/changes/archive/2026-03-31-webmcp-search-input/specs/webmcp-search-integration/spec.md
+++ b/openspec/changes/archive/2026-03-31-webmcp-search-input/specs/webmcp-search-integration/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: WebMCP Search Discoverability
+The system SHALL expose the site's search functionality to AI agents via standard WebMCP declarations (e.g., a static WebMCP manifest or semantic HTML attributes).
+
+#### Scenario: Agent discovers search
+- **WHEN** an AI agent inspects the website context
+- **THEN** it can identify the search tool, its endpoint, and required parameters (like the search query).
+
+### Requirement: WebMCP Integration Testing
+The system SHALL include an automated test to verify the presence of the WebMCP integration.
+
+#### Scenario: Validate WebMCP metadata
+- **WHEN** the test suite is executed
+- **THEN** it confirms that the WebMCP manifest or metadata is correctly served on the site.

--- a/openspec/changes/archive/2026-03-31-webmcp-search-input/tasks.md
+++ b/openspec/changes/archive/2026-03-31-webmcp-search-input/tasks.md
@@ -1,0 +1,19 @@
+## 1. Backend JSON Search Endpoint
+
+- [x] 1.1 Update `SearchController.java` to add a new REST endpoint: `GET /api/v2/catalog/search?q={query}`.
+- [x] 1.2 Implement the endpoint to leverage `CatalogService` or `LuceneSearchService` to return a JSON array of search results, matching the structure expected by the AI agent.
+
+## 2. Dynamic WebMCP JavaScript Integration
+
+- [x] 2.1 Update the default layout template (`src/main/resources/templates/layout/default.html`) to include the official WebMCP JavaScript snippet.
+- [x] 2.2 Securely wrap the execution payload in the script: `if (window.navigator.modelContext) { navigator.modelContext.registerTool(...) }` pointing its internal `fetch` API to our new `/api/v2/catalog/search` endpoint.
+
+## 3. Automated Testing & Verification
+
+- [x] 3.1 Write a robust `@SpringBootTest` equipped with `MockMvc` (e.g., `WebMcpIntegrationTest.java`).
+- [x] 3.2 Add a test case verifying the new JSON search endpoint works correctly.
+- [x] 3.3 Add a test case verifying the homepage (`/`) accurately serves the `<script>` tag containing the WebMCP registration logic.
+
+## 4. Documentation
+
+- [x] ~~4.1 Update `README-webmcp.md`~~ *(Deleted per user review - keeping repository pristine)*

--- a/openspec/specs/webmcp-search-integration/spec.md
+++ b/openspec/specs/webmcp-search-integration/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: WebMCP Search Discoverability
+The system SHALL expose the site's search functionality to AI agents via standard WebMCP declarations (e.g., a static WebMCP manifest or semantic HTML attributes).
+
+#### Scenario: Agent discovers search
+- **WHEN** an AI agent inspects the website context
+- **THEN** it can identify the search tool, its endpoint, and required parameters (like the search query).
+
+### Requirement: WebMCP Integration Testing
+The system SHALL include an automated test to verify the presence of the WebMCP integration.
+
+#### Scenario: Validate WebMCP metadata
+- **WHEN** the test suite is executed
+- **THEN** it confirms that the WebMCP manifest or metadata is correctly served on the site.

--- a/src/main/java/com/xceptance/posters/controller/SearchController.java
+++ b/src/main/java/com/xceptance/posters/controller/SearchController.java
@@ -12,6 +12,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.xceptance.posters.entity.CatalogProductRepository;
 import com.xceptance.posters.entity.LocalizedTextService;
@@ -69,6 +70,23 @@ public class SearchController
         model.addAttribute("searchText", searchText);
         model.addAttribute("totalCount", results.size());
         return "search/searchResult";
+    }
+
+    /**
+     * JSON search API for WebMCP agents and dynamic frontends.
+     */
+    @GetMapping(value = "/api/v2/catalog/search", produces = "application/json")
+    @ResponseBody
+    public List<SearchProductDto> searchJson(@RequestParam("q") String searchText,
+                                             @RequestParam(value = "locale", defaultValue = "en-US") String locale)
+    {
+        if (searchText == null || searchText.isBlank())
+        {
+            return List.of();
+        }
+
+        String currency = getCurrencyForLocale(locale);
+        return findByLucene(searchText, locale, currency, 100);
     }
 
     /**

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -23,6 +23,35 @@
 
     <!-- HTMX -->
     <script th:src="@{/assets/js/htmx.min.js}"></script>
+
+    <!-- WebMCP: Browser Native Agent API Registry -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+          if (window.navigator && window.navigator.modelContext) {
+              window.navigator.modelContext.registerTool({
+                  name: "search_catalog",
+                  description: "Searches the store catalog for products matching a given query. Use this to find specific items, brands, or categories.",
+                  parameters: {
+                      type: "object",
+                      properties: {
+                          query: {
+                              type: "string",
+                              description: "The search term to look for, e.g., 'laptop' or 'shoes'"
+                          }
+                      },
+                      required: ["query"]
+                  },
+                  execute: async (params) => {
+                      const url = `/api/v2/catalog/search?q=${encodeURIComponent(params.query)}`;
+                      const response = await fetch(url, { headers: { "Accept": "application/json" } });
+                      if (!response.ok) throw new Error("Search failed with status " + response.status);
+                      return await response.json();
+                  }
+              });
+              console.log("🤖 WebMCP tools registered for AI agents.");
+          }
+      });
+    </script>
 </head>
 
 <body>

--- a/src/test/java/com/xceptance/posters/entity/WebMcpIntegrationTest.java
+++ b/src/test/java/com/xceptance/posters/entity/WebMcpIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.xceptance.posters.entity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WebMcpIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testWebMcpBrowserApiInjection() throws Exception {
+        // The javascript modelContext.registerTool should be present in the default layout
+        mockMvc.perform(get("/en-US/"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+            .andExpect(content().string(containsString("window.navigator.modelContext.registerTool")));
+    }
+    
+    @Test
+    void testJsonSearchEndpointForAgents() throws Exception {
+        // The JSON backend search endpoint should correctly return product data
+        mockMvc.perform(get("/api/v2/catalog/search")
+                .param("q", "Posters")
+                .param("locale", "en-US")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$").isArray());
+    }
+}


### PR DESCRIPTION
Manual Testing:
1. Enable WebMCP in chrome: Paste this exact URL into your Chrome address bar: chrome://flags/#enable-webmcp-testing
2. Change the dropdown for WebMCP for testing to Enabled
3. Click the Relaunch button that appears at the bottom
4. Go to the Chrome Web Store and install the WebMCP Inspector
5. Check console for registration
6. Use WebMCP Inspector for further testing
<img width="1134" height="823" alt="image" src="https://github.com/user-attachments/assets/f0b2cd1b-672e-4b24-8bd9-a255344f4453" />


